### PR TITLE
Sync/use ff 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,24 +1,22 @@
 [package]
-name = "poseidon-circuit"
-version = "0.1.0"
+name = "poseidon-rs"
+version = "0.1.1"
 edition = "2021"
-
+autotests = false
+autobenches = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2022_09_10" }
 lazy_static = "1.4.0"
 thiserror = "1.0"
 bitvec = "1"
 log = "0.4.0"
 rand_xorshift = "0.3.0"
 rand = "0.8"
-
-[patch."https://github.com/privacy-scaling-explorations/halo2.git"]
-halo2_proofs = { git = "https://github.com/scroll-tech/halo2.git", branch = "develop" }
+ff = "0.13"
 
 [features]
-default = ["halo2_proofs/parallel_syn","short"]
+default = []
 # Use an implementation using fewer rows (8) per permutation.
 short = []
 # printout the layout of circuits for demo and some unittests
@@ -31,10 +29,11 @@ rand_chacha = "0.3.0"
 plotters = "0.3"
 bencher = "0.1"
 subtle = "2"
+halo2_proofs = { git = "https://github.com/axiom-crypto/halo2.git", branch = "sync/use-ff-0.13" }
 
-[[bench]]
-name = "hash"
-harness = false
+# [[bench]]
+# name = "hash"
+# harness = false
 
 [profile.test]
 opt-level = 3

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,12 +6,13 @@
 #![allow(unused_macros)]
 #![deny(missing_docs)]
 #![deny(unsafe_code)]
+#![feature(trait_alias)]
 
-pub mod hash;
+//pub mod hash;
 pub mod poseidon;
 
-pub use halo2_proofs::halo2curves::bn256::Fr as Bn256Fr;
-pub use hash::{Hashable, HASHABLE_DOMAIN_SPEC};
+//pub use halo2_proofs::halo2curves::bn256::Fr as Bn256Fr;
+//pub use hash::{Hashable, HASHABLE_DOMAIN_SPEC};
 
 /// a default step can be compatible with codehash circuit
 pub const DEFAULT_STEP: usize = 62;

--- a/src/poseidon.rs
+++ b/src/poseidon.rs
@@ -1,5 +1,7 @@
 //! The Poseidon algebraic hash function.
 
+pub mod primitives;
+/*
 use std::convert::TryInto;
 use std::fmt;
 use std::marker::PhantomData;
@@ -326,3 +328,4 @@ impl<
             .squeeze(layouter.namespace(|| "squeeze"))
     }
 }
+*/

--- a/src/poseidon/primitives.rs
+++ b/src/poseidon/primitives.rs
@@ -43,8 +43,6 @@ pub(crate) type SpongeRate<F, const RATE: usize> = [Option<F>; RATE];
 /// The type used to hold the MDS matrix and its inverse.
 pub(crate) type Mds<F, const T: usize> = [[F; T]; T];
 
-pub trait FieldExt = FromUniformBytes<64> + Ord;
-
 /// A specification for a Poseidon permutation.
 pub trait Spec<F: PrimeField, const T: usize, const RATE: usize>: fmt::Debug {
     /// The number of full rounds for this specification.
@@ -68,7 +66,7 @@ pub trait Spec<F: PrimeField, const T: usize, const RATE: usize>: fmt::Debug {
     /// Generates `(round_constants, mds, mds^-1)` corresponding to this specification.
     fn constants() -> (Vec<[F; T]>, Mds<F, T>, Mds<F, T>)
     where
-        F: FieldExt,
+        F: FromUniformBytes<64> + Ord,
     {
         let r_f = Self::full_rounds();
         let r_p = Self::partial_rounds();
@@ -220,7 +218,7 @@ impl<F: PrimeField, S: Spec<F, T, RATE>, const T: usize, const RATE: usize>
     /// Constructs a new sponge for the given Poseidon specification.
     pub(crate) fn new(initial_capacity_element: F, layout: usize) -> Self
     where
-        F: FieldExt,
+        F: FromUniformBytes<64> + Ord,
     {
         let (round_constants, mds_matrix, _) = S::constants();
 
@@ -440,7 +438,7 @@ impl<F: PrimeField, S: Spec<F, T, RATE>, D: Domain<F, RATE>, const T: usize, con
     /// Initializes a new hasher.
     pub fn init() -> Self
     where
-        F: FieldExt,
+        F: FromUniformBytes<64> + Ord,
     {
         Hash {
             sponge: Sponge::new(D::initial_capacity_element(), D::layout(T)),
@@ -506,8 +504,9 @@ impl<F: PrimeField, S: Spec<F, T, RATE>, const T: usize, const RATE: usize>
 
 #[cfg(test)]
 mod tests {
+    use ff::PrimeField;
+
     use super::pasta::Fp;
-    use super::FieldExt;
 
     use super::{permute, ConstantLength, Hash, P128Pow5T3, P128Pow5T3Compact, Spec};
     type OrchardNullifier = P128Pow5T3<Fp>;

--- a/src/poseidon/primitives/bn256/mod.rs
+++ b/src/poseidon/primitives/bn256/mod.rs
@@ -136,7 +136,7 @@ mod tests {
         ];
 
         let output = {
-            let mut state = input.clone();
+            let mut state = input;
 
             let (rc, mds, _inv) = P128Pow5T3::<Fp>::constants();
             permute::<Fp, P128Pow5T3<Fp>, 3, 2>(&mut state, &mds, &rc[..]);
@@ -148,7 +148,7 @@ mod tests {
         };
 
         let output_compact = {
-            let mut state = input.clone();
+            let mut state = input;
 
             let (rc, mds, _inv) = P128Pow5T3Compact::<Fp>::constants();
             permute::<Fp, P128Pow5T3Compact<Fp>, 3, 2>(&mut state, &mds, &rc[..]);

--- a/src/poseidon/primitives/grain.rs
+++ b/src/poseidon/primitives/grain.rs
@@ -3,7 +3,7 @@
 use std::marker::PhantomData;
 
 use bitvec::prelude::*;
-use halo2_proofs::arithmetic::FieldExt;
+use ff::FromUniformBytes;
 
 const STATE: usize = 80;
 
@@ -43,13 +43,13 @@ impl SboxType {
     }
 }
 
-pub(super) struct Grain<F: FieldExt> {
+pub(super) struct Grain<F> {
     state: BitArr!(for 80, in u8, Msb0),
     next_bit: usize,
     _field: PhantomData<F>,
 }
 
-impl<F: FieldExt> Grain<F> {
+impl<F: FromUniformBytes<64>> Grain<F> {
     pub(super) fn new(sbox: SboxType, t: u16, r_f: u16, r_p: u16) -> Self {
         // Initialize the LFSR state.
         let mut state = bitarr![u8, Msb0; 1; STATE];
@@ -161,11 +161,11 @@ impl<F: FieldExt> Grain<F> {
             view[i / 8] |= if bit { 1 << (i % 8) } else { 0 };
         }
 
-        F::from_bytes_wide(&bytes)
+        F::from_uniform_bytes(&bytes)
     }
 }
 
-impl<F: FieldExt> Iterator for Grain<F> {
+impl<F: FromUniformBytes<64>> Iterator for Grain<F> {
     type Item = bool;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/poseidon/primitives/grain.rs
+++ b/src/poseidon/primitives/grain.rs
@@ -3,7 +3,7 @@
 use std::marker::PhantomData;
 
 use bitvec::prelude::*;
-use ff::FromUniformBytes;
+use ff::{FromUniformBytes, PrimeField};
 
 const STATE: usize = 80;
 
@@ -49,7 +49,7 @@ pub(super) struct Grain<F> {
     _field: PhantomData<F>,
 }
 
-impl<F: FromUniformBytes<64>> Grain<F> {
+impl<F: PrimeField> Grain<F> {
     pub(super) fn new(sbox: SboxType, t: u16, r_f: u16, r_p: u16) -> Self {
         // Initialize the LFSR state.
         let mut state = bitarr![u8, Msb0; 1; STATE];
@@ -138,7 +138,10 @@ impl<F: FromUniformBytes<64>> Grain<F> {
 
     /// Returns the next field element from this Grain instantiation, without using
     /// rejection sampling.
-    pub(super) fn next_field_element_without_rejection(&mut self) -> F {
+    pub(super) fn next_field_element_without_rejection(&mut self) -> F
+    where
+        F: FromUniformBytes<64>,
+    {
         let mut bytes = [0u8; 64];
 
         // Poseidon reference impl interprets the bits as a repr in MSB order, because
@@ -165,7 +168,7 @@ impl<F: FromUniformBytes<64>> Grain<F> {
     }
 }
 
-impl<F: FromUniformBytes<64>> Iterator for Grain<F> {
+impl<F: PrimeField> Iterator for Grain<F> {
     type Item = bool;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/poseidon/primitives/mds.rs
+++ b/src/poseidon/primitives/mds.rs
@@ -1,8 +1,8 @@
-use halo2_proofs::arithmetic::FieldExt;
+use ff::FromUniformBytes;
 
 use super::{grain::Grain, Mds};
 
-pub(super) fn generate_mds<F: FieldExt, const T: usize>(
+pub(super) fn generate_mds<F: Ord + FromUniformBytes<64>, const T: usize>(
     grain: &mut Grain<F>,
     mut select: usize,
 ) -> (Mds<F, T>, Mds<F, T>) {
@@ -48,7 +48,7 @@ pub(super) fn generate_mds<F: FieldExt, const T: usize>(
         // However, the Poseidon paper and reference impl use the positive formulation,
         // and we want to rely on the reference impl for MDS security, so we use the same
         // formulation.
-        let mut mds = [[F::zero(); T]; T];
+        let mut mds = [[F::ZERO; T]; T];
         #[allow(clippy::needless_range_loop)]
         for i in 0..T {
             for j in 0..T {
@@ -74,10 +74,10 @@ pub(super) fn generate_mds<F: FieldExt, const T: usize>(
     // where A_i(x) and B_i(x) are the Lagrange polynomials for xs and ys respectively.
     //
     // We adapt this to the positive Cauchy formulation by negating ys.
-    let mut mds_inv = [[F::zero(); T]; T];
+    let mut mds_inv = [[F::ZERO; T]; T];
     let l = |xs: &[F], j, x: F| {
         let x_j = xs[j];
-        xs.iter().enumerate().fold(F::one(), |acc, (m, x_m)| {
+        xs.iter().enumerate().fold(F::ONE, |acc, (m, x_m)| {
             if m == j {
                 acc
             } else {
@@ -100,8 +100,9 @@ pub(super) fn generate_mds<F: FieldExt, const T: usize>(
 #[cfg(test)]
 mod tests {
     use super::super::pasta::Fp;
-
     use super::{generate_mds, Grain};
+
+    use ff::Field;
 
     #[test]
     fn poseidon_mds() {
@@ -113,9 +114,9 @@ mod tests {
         #[allow(clippy::needless_range_loop)]
         for i in 0..T {
             for j in 0..T {
-                let expected = if i == j { Fp::one() } else { Fp::zero() };
+                let expected = if i == j { Fp::ONE } else { Fp::ZERO };
                 assert_eq!(
-                    (0..T).fold(Fp::zero(), |acc, k| acc + (mds[i][k] * mds_inv[k][j])),
+                    (0..T).fold(Fp::ZERO, |acc, k| acc + (mds[i][k] * mds_inv[k][j])),
                     expected
                 );
             }

--- a/src/poseidon/primitives/p128pow5t3.rs
+++ b/src/poseidon/primitives/p128pow5t3.rs
@@ -76,7 +76,7 @@ mod tests {
         }
 
         fn sbox(val: F) -> F {
-            val.pow_vartime(&[5])
+            val.pow_vartime([5])
         }
 
         fn secure_mds() -> usize {

--- a/src/poseidon/primitives/p128pow5t3.rs
+++ b/src/poseidon/primitives/p128pow5t3.rs
@@ -1,9 +1,11 @@
 use std::marker::PhantomData;
 
-use super::{FieldExt, Mds, Spec};
+use ff::PrimeField;
+
+use super::{Mds, Spec};
 
 /// The trait required for fields can handle a pow5 sbox, 3 field, 2 rate permutation
-pub trait P128Pow5T3Constants: FieldExt {
+pub trait P128Pow5T3Constants: PrimeField {
     fn partial_rounds() -> usize {
         56
     }
@@ -49,8 +51,9 @@ impl<Fp: P128Pow5T3Constants> Spec<Fp, 3, 2> for P128Pow5T3<Fp> {
 mod tests {
     use std::marker::PhantomData;
 
+    use ff::{FromUniformBytes, PrimeField};
+
     use super::super::pasta::{fp, test_vectors, Fp};
-    use super::FieldExt;
     use crate::poseidon::primitives::{permute, ConstantLength, Hash, Spec};
 
     /// The same Poseidon specification as poseidon::P128Pow5T3, but constructed
@@ -60,13 +63,13 @@ mod tests {
 
     type P128Pow5T3Pasta = super::P128Pow5T3<Fp>;
 
-    impl<F: FieldExt, const SECURE_MDS: usize> P128Pow5T3Gen<F, SECURE_MDS> {
+    impl<F: PrimeField, const SECURE_MDS: usize> P128Pow5T3Gen<F, SECURE_MDS> {
         pub fn new() -> Self {
             P128Pow5T3Gen(PhantomData::default())
         }
     }
 
-    impl<F: FieldExt, const SECURE_MDS: usize> Spec<F, 3, 2> for P128Pow5T3Gen<F, SECURE_MDS> {
+    impl<F: PrimeField, const SECURE_MDS: usize> Spec<F, 3, 2> for P128Pow5T3Gen<F, SECURE_MDS> {
         fn full_rounds() -> usize {
             8
         }
@@ -86,7 +89,7 @@ mod tests {
 
     #[test]
     fn verify_constants() {
-        fn verify_constants_helper<F: FieldExt>(
+        fn verify_constants_helper<F: FromUniformBytes<64> + Ord>(
             expected_round_constants: [[F; 3]; 64],
             expected_mds: [[F; 3]; 3],
             expected_mds_inv: [[F; 3]; 3],

--- a/src/poseidon/primitives/p128pow5t3.rs
+++ b/src/poseidon/primitives/p128pow5t3.rs
@@ -1,7 +1,6 @@
-use halo2_proofs::arithmetic::FieldExt;
 use std::marker::PhantomData;
 
-use super::{Mds, Spec};
+use super::{FieldExt, Mds, Spec};
 
 /// The trait required for fields can handle a pow5 sbox, 3 field, 2 rate permutation
 pub trait P128Pow5T3Constants: FieldExt {
@@ -50,16 +49,14 @@ impl<Fp: P128Pow5T3Constants> Spec<Fp, 3, 2> for P128Pow5T3<Fp> {
 mod tests {
     use std::marker::PhantomData;
 
-    use halo2_proofs::arithmetic::FieldExt;
-    use halo2_proofs::halo2curves::group::ff::PrimeField;
-
     use super::super::pasta::{fp, test_vectors, Fp};
+    use super::FieldExt;
     use crate::poseidon::primitives::{permute, ConstantLength, Hash, Spec};
 
     /// The same Poseidon specification as poseidon::P128Pow5T3, but constructed
     /// such that its constants will be generated at runtime.
     #[derive(Debug)]
-    pub struct P128Pow5T3Gen<F: FieldExt, const SECURE_MDS: usize>(PhantomData<F>);
+    pub struct P128Pow5T3Gen<F, const SECURE_MDS: usize>(PhantomData<F>);
 
     type P128Pow5T3Pasta = super::P128Pow5T3<Fp>;
 

--- a/src/poseidon/primitives/p128pow5t3_compact.rs
+++ b/src/poseidon/primitives/p128pow5t3_compact.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use halo2_proofs::arithmetic::FieldExt;
+use ff::PrimeField;
 
 use super::p128pow5t3::P128Pow5T3Constants;
 use super::{Mds, Spec};
@@ -55,8 +55,8 @@ impl<Fp: P128Pow5T3Constants> Spec<Fp, 3, 2> for P128Pow5T3Compact<Fp> {
     }
 }
 
-fn mat_mul<Fp: FieldExt, const T: usize>(mat: &Mds<Fp, T>, input: &[Fp; T]) -> [Fp; T] {
-    let mut out = [Fp::zero(); T];
+fn mat_mul<Fp: PrimeField, const T: usize>(mat: &Mds<Fp, T>, input: &[Fp; T]) -> [Fp; T] {
+    let mut out = [Fp::ZERO; T];
     #[allow(clippy::needless_range_loop)]
     for i in 0..T {
         for j in 0..T {
@@ -66,17 +66,17 @@ fn mat_mul<Fp: FieldExt, const T: usize>(mat: &Mds<Fp, T>, input: &[Fp; T]) -> [
     out
 }
 
-fn vec_accumulate<Fp: FieldExt, const T: usize>(a: &mut [Fp; T], b: &[Fp; T]) {
+fn vec_accumulate<Fp: PrimeField, const T: usize>(a: &mut [Fp; T], b: &[Fp; T]) {
     for i in 0..T {
         a[i] += b[i];
     }
 }
 
-fn vec_remove_tail<Fp: FieldExt, const T: usize>(a: &mut [Fp; T]) -> [Fp; T] {
-    let mut tail = [Fp::zero(); T];
+fn vec_remove_tail<Fp: PrimeField, const T: usize>(a: &mut [Fp; T]) -> [Fp; T] {
+    let mut tail = [Fp::ZERO; T];
     for i in 1..T {
         tail[i] = a[i];
-        a[i] = Fp::zero();
+        a[i] = Fp::ZERO;
     }
     tail
 }

--- a/src/poseidon/primitives/pasta/mod.rs
+++ b/src/poseidon/primitives/pasta/mod.rs
@@ -29,7 +29,7 @@ fn sqrt_tonelli_shanks<F: PrimeField, S: AsRef<[u64]>>(f: &F, tm1d2: S) -> subtl
     let mut b = x * w;
 
     // Initialize z as the 2^S root of unity.
-    let mut z = F::root_of_unity();
+    let mut z = F::ROOT_OF_UNITY;
 
     for max_v in (1..=F::S).rev() {
         let mut k = 1;
@@ -37,7 +37,7 @@ fn sqrt_tonelli_shanks<F: PrimeField, S: AsRef<[u64]>>(f: &F, tm1d2: S) -> subtl
         let mut j_less_than_v: Choice = 1.into();
 
         for j in 2..max_v {
-            let tmp_is_one = tmp.ct_eq(&F::one());
+            let tmp_is_one = tmp.ct_eq(&F::ONE);
             let squared = F::conditional_select(&tmp, &z, tmp_is_one).square();
             tmp = F::conditional_select(&squared, &tmp, tmp_is_one);
             let new_z = F::conditional_select(&z, &squared, tmp_is_one);
@@ -47,7 +47,7 @@ fn sqrt_tonelli_shanks<F: PrimeField, S: AsRef<[u64]>>(f: &F, tm1d2: S) -> subtl
         }
 
         let result = x * z;
-        x = F::conditional_select(&result, &x, b.ct_eq(&F::one()));
+        x = F::conditional_select(&result, &x, b.ct_eq(&F::ONE));
         z = z.square();
         b *= z;
         v = k;


### PR DESCRIPTION
Disable circuit modules, remove halo2_proofs as non-dev dependency. This crate is only for the native rust Poseidon implementation now.

Use ff `v0.13`.